### PR TITLE
Remove parentheses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,11 @@ VHDLS   := $(filter-out todo.vhd,$(VHDLS))
 
 all: vhdlcheck diff
 
-# This rule is only helpful for a quick start;
-# it doesn't understand the actual dependencies for rebuilds.
-src/vhd2vl:
-	make -C src
-
 vhdlcheck:
 	@make -C examples
 
-translate: src/vhd2vl
+translate:
+	@make -C src
 	@mkdir -p temp/verilog
 	@cd examples; $(foreach VHDL,$(VHDLS), echo "Translating: $(VHDL)";../src/vhd2vl --quiet $(VHDL) ../temp/verilog/$(basename $(VHDL)).v;)
 
@@ -26,7 +22,8 @@ diff: translate
 verilogcheck:
 	@cd translated_examples; for f in *.v; do echo "Checking: $$f"; $(VERILOG) $$f; done
 
-todo: src/vhd2vl
+todo:
+	@make -C src
 	src/vhd2vl --quiet examples/todo.vhd temp/todo.v
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,24 @@
 #!/usr/bin/make
 
-VERILOG  = iverilog -Wall -y . -t null
-EXAMPLES = $(wildcard examples/*.vhd)
-VHDLS    = $(notdir $(EXAMPLES))
-VHDLS   := $(filter-out todo.vhd,$(VHDLS))
+VHDLS  = $(wildcard examples/*.vhd)
+VHDLS := $(notdir $(VHDLS))
+VHDLS := $(filter-out todo.vhd,$(VHDLS))
 
-all: vhdlcheck diff
-
-vhdlcheck:
-	@make -C examples
+all: diff
 
 translate:
 	@make -C src
+	@make -C examples
 	@mkdir -p temp/verilog
-	@cd examples; $(foreach VHDL,$(VHDLS), echo "Translating: $(VHDL)";../src/vhd2vl --quiet $(VHDL) ../temp/verilog/$(basename $(VHDL)).v;)
+	@echo "##### Translating Examples #####################################"
+	@cd examples; $(foreach VHDL,$(VHDLS), echo "Translating: $(VHDL)";\
+	../src/vhd2vl --quiet $(VHDL) ../temp/verilog/$(basename $(VHDL)).v;)
+	@make -C translated_examples
 
 diff: translate
-	diff -u translated_examples temp/verilog
+	@echo "##### Diff #####################################################"
+	diff -u --exclude=Makefile translated_examples temp/verilog
 	@echo "PASS"
-
-verilogcheck:
-	@cd translated_examples; for f in *.v; do echo "Checking: $$f"; $(VERILOG) $$f; done
 
 todo:
 	@make -C src
@@ -28,5 +26,4 @@ todo:
 
 clean:
 	make -C src clean
-	@make -C examples clean
 	rm -fr temp

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,11 +1,13 @@
 #!/usr/bin/make
-# by RAM 2017
 
 TEMP = ../temp/vhdl
 
 all:
+ifneq ($(shell which ghdl),)
 	@mkdir -p $(TEMP)
+	@echo "##### Checking examples with GHDL ##############################"
 	ghdl -a --workdir=$(TEMP) *.vhd
+endif
 
 clean:
 	rm -fr $(TEMP)

--- a/src/vhd2vl.y
+++ b/src/vhd2vl.y
@@ -2350,10 +2350,10 @@ simple_expr : signal {
        $$=addexpr($1,'/'," / ",$3);
       }
      | CONVFUNC_1 '(' simple_expr ')' {
-       /* one argument type conversion e.g. conv_integer(x) */
+       /* one argument type conversion e.g. to_integer(x) */
        expdata *e;
        e=xmalloc(sizeof(expdata));
-       e->sl=addwrap("(",$3->sl,")");
+       e->sl=addsl(NULL,$3->sl);
        $$=e;
       }
      | '(' simple_expr ')' {

--- a/src/vhd2vl.y
+++ b/src/vhd2vl.y
@@ -313,7 +313,7 @@ expdata *addnest(struct expdata *inner)
   if (inner->op == 'c') {
     e->sl=addwrap("{",inner->sl,"}");
   } else {
-    e->sl=addwrap("(",inner->sl,")");
+    e->sl=addsl(NULL,inner->sl);
   }
   return e;
 }

--- a/src/vhd2vl.y
+++ b/src/vhd2vl.y
@@ -2149,15 +2149,8 @@ expr : signal {
      | expr XOR expr {$$=addexpr($1,'^'," ^ ",$3);}
      | expr XNOR expr {$$=addexpr(NULL,'~'," ~",addexpr($1,'^'," ^ ",$3));}
      | BITVECT '(' expr ')' {
-       /* single argument type conversion function e.g. std_ulogic_vector(x) */
-       expdata *e;
-       e=xmalloc(sizeof(expdata));
-       if ($3->op == 'c') {
-         e->sl=addwrap("{",$3->sl,"}");
-       } else {
-         e->sl=addwrap("(",$3->sl,")");
-       }
-       $$=e;
+       /* single argument type conversion function e.g. std_logic_vector(x) */
+       $$ = addnest($3);
       }
      | CONVFUNC_2 '(' expr ',' NATURAL ')' {
        /* two argument type conversion e.g. to_unsigned(x, 3) */

--- a/src/vhd2vl.y
+++ b/src/vhd2vl.y
@@ -2352,7 +2352,8 @@ simple_expr : signal {
      | '(' simple_expr ')' {
        expdata *e;
        e=xmalloc(sizeof(expdata));
-       e->sl=addwrap("(",$2->sl,")");
+       //e->sl=addwrap("(",$2->sl,")");
+       e->sl=addsl(NULL,$2->sl);
        $$=e;
       }
      ;

--- a/translated_examples/Makefile
+++ b/translated_examples/Makefile
@@ -1,0 +1,14 @@
+#!/usr/bin/make
+
+TEMP = ../temp/verilog
+
+all:
+ifneq ($(shell which iverilog),)
+	@mkdir -p $(TEMP)
+	@echo "##### Checking resulting Verilog files with iVerilog ###########"
+	@-cd $(TEMP); $(foreach VERILOG,$(wildcard *.v), echo "Checking: $(VERILOG)";\
+	iverilog -Wall -y . -t null $(VERILOG);)
+endif
+
+clean:
+	rm -fr $(TEMP)

--- a/translated_examples/bigfile.v
+++ b/translated_examples/bigfile.v
@@ -102,17 +102,17 @@ wire [31:0] g_sys_in_ii;
 wire [31:0] g_dout_i;
 
   // qaz out
-  assign g_zaq_out_i = ((g_secondary_t_l_dout & ((g_aux ^ g_style_t_y_dout)))) | ((g_alu_l_dout & alu_u &  ~g_secondary_t_l_dout)) | (( ~g_alu_l_dout &  ~g_secondary_t_l_dout & g_t_u_dout));
+  assign g_zaq_out_i = (g_secondary_t_l_dout & (g_aux ^ g_style_t_y_dout)) | (g_alu_l_dout & alu_u &  ~g_secondary_t_l_dout) | ( ~g_alu_l_dout &  ~g_secondary_t_l_dout & g_t_u_dout);
   // Changed
   assign g_zaq_out = g_zaq_out_i &  ~g_t_jkl_sink_l_dout;
   // qaz 
   // JLB
-  assign g_zaq_ctl_i =  ~((((g_t_l_dout &  ~g_t_jkl_sink_l_dout)) | ((g_t_l_dout & g_t_jkl_sink_l_dout &  ~g_zaq_out_i))));
+  assign g_zaq_ctl_i =  ~((g_t_l_dout &  ~g_t_jkl_sink_l_dout) | (g_t_l_dout & g_t_jkl_sink_l_dout &  ~g_zaq_out_i));
   // mux
   //vnavigatoroff
   assign g_zaq_ctl = scanb == 1'b1 ? g_zaq_ctl_i : 32'b00000000000000000000000000000000;
   //vnavigatoron
-  assign g_zaq_hhh_enb =  ~((g_t_hhh_l_dout));
+  assign g_zaq_hhh_enb =  ~(g_t_hhh_l_dout);
   assign g_zaq_qaz_hb = g_t_qaz_mult_high_dout;
   assign g_zaq_qaz_lb = g_t_qaz_mult_low_dout;
   // Dout
@@ -287,12 +287,12 @@ wire [31:0] g_dout_i;
   // switch
   assign g_zaq_in_y = g_style_t_y_dout ^ q2_g_zaq_in;
   // qaz
-  assign g_style_vfr_dout = {g_zaq_in_y[31:4],(((g_style_c_l_dout[3:0] & q_g_zaq_in_cd)) | (( ~g_style_c_l_dout[3:0] & g_zaq_in_y[3:0])))};
+  assign g_style_vfr_dout = {g_zaq_in_y[31:4],(g_style_c_l_dout[3:0] & q_g_zaq_in_cd) | ( ~g_style_c_l_dout[3:0] & g_zaq_in_y[3:0])};
   // in scan mode
-  assign g_zaq_in_y_no_dout = scanb == 1'b1 ? (g_style_t_y_dout ^ g_zaq_in) : g_style_t_y_dout;
+  assign g_zaq_in_y_no_dout = scanb == 1'b1 ? g_style_t_y_dout ^ g_zaq_in : g_style_t_y_dout;
   //vnavigatoron
-  assign g_sys_in_i = ({g_zaq_in_y_no_dout[31:4],(((g_style_c_l_dout[3:0] & q_g_zaq_in_cd)) | (( ~g_style_c_l_dout[3:0] & g_zaq_in_y_no_dout[3:0])))});
-  assign g_sys_in_ii = ((g_sys_in_i &  ~gwerthernal_style_l_dout)) | ((gwerthernal_style_u_dout & gwerthernal_style_l_dout));
+  assign g_sys_in_i = {g_zaq_in_y_no_dout[31:4],(g_style_c_l_dout[3:0] & q_g_zaq_in_cd) | ( ~g_style_c_l_dout[3:0] & g_zaq_in_y_no_dout[3:0])};
+  assign g_sys_in_ii = (g_sys_in_i &  ~gwerthernal_style_l_dout) | (gwerthernal_style_u_dout & gwerthernal_style_l_dout);
   assign g_sys_in = g_sys_in_ii;
   always @(posedge reset, posedge sysclk) begin
     if((reset != 1'b0)) begin
@@ -344,7 +344,7 @@ wire [31:0] g_dout_i;
   end
 
   // generate
-  assign g_n_active = (((((q_g_style_vfr_dout &  ~g_style_vfr_dout)) | (( ~q_g_style_vfr_dout & g_style_vfr_dout & g_n_both_qbars_l_dout))))) & g_n_l_dout;
+  assign g_n_active = ((q_g_style_vfr_dout &  ~g_style_vfr_dout) | ( ~q_g_style_vfr_dout & g_style_vfr_dout & g_n_both_qbars_l_dout)) & g_n_l_dout;
   // check for lqq active and set lqq vfr register
   // also clear
   always @(posedge reset, posedge sysclk) begin
@@ -405,7 +405,7 @@ wire [31:0] g_dout_i;
           g_vector[8 * i + 7:8 * i] <= g_e_n_r_dout[8 * idiv8 + 7:8 * idiv8];
         end
         else begin
-          g_vector[8 * i + 7:8 * i] <= (((g_e_n_r_dout[8 * idiv8 + 7:8 * idiv8])) + ((imod8)));
+          g_vector[8 * i + 7:8 * i] <= (g_e_n_r_dout[8 * idiv8 + 7:8 * idiv8]) + (imod8);
         end
       end
     end

--- a/translated_examples/clk.v
+++ b/translated_examples/clk.v
@@ -21,7 +21,7 @@ reg [4:7 - 1] egg;
     if((reset != 1'b0)) begin
       foo <= {(((10 + 3))-((0))+1){1'b1}};
     end else begin
-      foo <= ival[31:31 - ((10 + 3))];
+      foo <= ival[31:31 - (10 + 3)];
     end
   end
 

--- a/translated_examples/counters.v
+++ b/translated_examples/counters.v
@@ -76,12 +76,12 @@ reg prev_do_file_card;
 
   //---
   // form the outputs
-  assign wfoo0_llwln = (wfoo0_llwln_var);
-  assign debct = (debct_var);
-  assign Z0 = (Z0_var);
-  assign Y1 = (Y1_var);
-  assign X2 = (X2_var);
-  assign W3 = (W3_var);
+  assign wfoo0_llwln = wfoo0_llwln_var;
+  assign debct = debct_var;
+  assign Z0 = Z0_var;
+  assign Y1 = Y1_var;
+  assign X2 = X2_var;
+  assign W3 = W3_var;
   assign Z0_cwm = Z0_cwm_i;
   assign Y1_cwm = Y1_cwm_i;
   assign X2_cwm = X2_cwm_i;
@@ -120,7 +120,7 @@ reg prev_do_file_card;
       //--
       //  wfoo0
       if(wfoo0_baz == 1'b1) begin
-        wfoo0_llwln_var <= (wfoo0_turn);
+        wfoo0_llwln_var <= wfoo0_turn;
         main_wfoo0_cwm <= 1'b0;
         if(wfoo0_llwln_var == 32'b00000000000000000000000000000000) begin
           do_q3p_wfoo0 <= 1'b0;
@@ -133,7 +133,7 @@ reg prev_do_file_card;
         if(do_q3p_wfoo0 == 1'b1 && wfoo0_blrb == 1'b1) begin
           wfoo0_llwln_var <= wfoo0_llwln_var - 1;
           if((wfoo0_llwln_var == 32'b00000000000000000000000000000000)) begin
-            wfoo0_llwln_var <= (wfoo0_turn);
+            wfoo0_llwln_var <= wfoo0_turn;
             if(main_wfoo0_cwm == 1'b0) begin
               wfoo0_cwm <= 1'b1;
               main_wfoo0_cwm <= 1'b1;
@@ -150,7 +150,7 @@ reg prev_do_file_card;
       end
       if(Z0_baz == 1'b1) begin
         // counter Baz
-        Z0_var <= (Z0_turn);
+        Z0_var <= Z0_turn;
         if(Z0_turn == 32'b00000000000000000000000000000000) begin
           do_q3p_Z0 <= 1'b0;
         end
@@ -175,7 +175,7 @@ reg prev_do_file_card;
             Z0_var <= Z0_var - 1;
             if((Z0_var == 32'b00000000000000000000000000000000)) begin
               Z0_cwm_i <= 1'b1;
-              Z0_var <= (Z0_turn);
+              Z0_var <= Z0_turn;
             end
           end
           // Z0_bar
@@ -187,7 +187,7 @@ reg prev_do_file_card;
       end
       if(Y1_baz == 1'b1) begin
         // counter Baz
-        Y1_var <= (Y1_turn);
+        Y1_var <= Y1_turn;
         if(Y1_turn == 32'b00000000000000000000000000000000) begin
           do_q3p_Y1 <= 1'b0;
         end
@@ -211,7 +211,7 @@ reg prev_do_file_card;
           Y1_var <= Y1_var - 1;
           if((Y1_var == 32'b00000000000000000000000000000000)) begin
             Y1_cwm_i <= 1'b1;
-            Y1_var <= (Y1_turn);
+            Y1_var <= Y1_turn;
           end
         end
         // Y1_bar
@@ -222,7 +222,7 @@ reg prev_do_file_card;
       end
       if(X2_baz == 1'b1) begin
         // counter Baz
-        X2_var <= (X2_turn);
+        X2_var <= X2_turn;
         if(X2_turn == 32'b00000000000000000000000000000000) begin
           do_q3p_X2 <= 1'b0;
         end
@@ -247,7 +247,7 @@ reg prev_do_file_card;
           if((X2_var == 32'b00000000000000000000000000000000)) begin
             //{
             X2_cwm_i <= 1'b1;
-            X2_var <= (X2_turn);
+            X2_var <= X2_turn;
           end
         end
         //X2_bar
@@ -258,7 +258,7 @@ reg prev_do_file_card;
       end
       if(W3_baz == 1'b1) begin
         // counter Baz
-        W3_var <= (W3_turn);
+        W3_var <= W3_turn;
         if(W3_turn == 32'b00000000000000000000000000000000) begin
           do_q3p_W3 <= 1'b0;
         end
@@ -283,7 +283,7 @@ reg prev_do_file_card;
           if((W3_var == 32'b00000000000000000000000000000000)) begin
             //{
             W3_cwm_i <= 1'b1;
-            W3_var <= (W3_turn);
+            W3_var <= W3_turn;
           end
         end
         // W3_bar
@@ -294,7 +294,7 @@ reg prev_do_file_card;
       end
       if(debct_baz == 1'b1) begin
         // counter Baz
-        debct_var <= (debct_turn);
+        debct_var <= debct_turn;
         if(debct_turn == 32'b00000000000000000000000000000000) begin
           do_q3p_debct <= 1'b0;
         end
@@ -324,7 +324,7 @@ reg prev_do_file_card;
             //{
             debct_cwm_i <= 1'b1;
             debct_pull <= 1'b1;
-            debct_var <= (debct_turn);
+            debct_var <= debct_turn;
           end
         end
         // debct_bar

--- a/translated_examples/dsp.v
+++ b/translated_examples/dsp.v
@@ -27,7 +27,7 @@ parameter [31:0] bus_width=24;
 wire foo;
 
   always @(clk) begin
-    dout <= ((1));
+    dout <= 1;
   end
 
 

--- a/translated_examples/expr.v
+++ b/translated_examples/expr.v
@@ -17,9 +17,9 @@ wire [8:0] input_status;
 wire enable; wire debug; wire aux; wire outy; wire dv; wire value;
 
   // drive input status
-  assign input_status = {foo[9:4],((((baz[2:0] & foo[3:0])) | (( ~baz[2:0] & bam[3:0]))))};
+  assign input_status = {foo[9:4],(baz[2:0] & foo[3:0]) | ( ~baz[2:0] & bam[3:0])};
   // drive based on foo
-  assign out_i[4] = ((enable & ((aux ^ outy)))) | ((debug & dv &  ~enable)) | (( ~debug &  ~enable & value));
+  assign out_i[4] = (enable & (aux ^ outy)) | (debug & dv &  ~enable) | ( ~debug &  ~enable & value);
   // not drive
   always @(negedge reset, negedge sysclk) begin
     if((reset != 1'b0)) begin

--- a/translated_examples/expr.v
+++ b/translated_examples/expr.v
@@ -25,7 +25,7 @@ wire enable; wire debug; wire aux; wire outy; wire dv; wire value;
     if((reset != 1'b0)) begin
       foo <= {14{1'b0}};
     end else begin
-      foo[3 * ((2 - 1))] <= baz[1 * ((1 + 2)) - 2];
+      foo[3 * (2 - 1)] <= baz[1 * (1 + 2) - 2];
       bam[13:0] <= foo;
     end
   end

--- a/translated_examples/generic.v
+++ b/translated_examples/generic.v
@@ -29,7 +29,7 @@ wire [31:0] complex;
       3'b101 : code[9:2] <= 8'b11100010;
       3'b010 : code[9:2] <= {8{1'b1}};
       3'b011 : code[9:2] <= {8{1'b0}};
-      default : code[9:2] <= (((a)) + ((b)));
+      default : code[9:2] <= (a) + (b);
     endcase
   end
 
@@ -37,6 +37,6 @@ wire [31:0] complex;
   assign foo = {(((1 + 1))-((0))+1){1'b0}};
   assign egg = {78{1'b0}};
   assign baz = {(((bus_width * 4))-((bus_width * 3 - 1))+1){1'b1}};
-  assign complex = {enf,((3'b110 * ((load)))),qtd[3:0],base,5'b11001};
+  assign complex = {enf,3'b110 * (load),qtd[3:0],base,5'b11001};
 
 endmodule

--- a/translated_examples/gh_fifo_async16_sr.v
+++ b/translated_examples/gh_fifo_async16_sr.v
@@ -75,7 +75,7 @@ reg isrst_r;
   //--- Write address counter -------------
   //---------------------------------------
   assign add_WR_CE = (ifull == 1'b1) ? 1'b0 : (WR == 1'b0) ? 1'b0 : 1'b1;
-  assign n_add_WR = (((add_WR)) + 4'h1);
+  assign n_add_WR = (add_WR) + 4'h1;
   always @(posedge clk_WR, posedge rst) begin
     if((rst == 1'b1)) begin
       add_WR <= {5{1'b0}};
@@ -108,7 +108,7 @@ reg isrst_r;
   //--- Read address counter --------------
   //---------------------------------------
   assign add_RD_CE = (iempty == 1'b1) ? 1'b0 : (RD == 1'b0) ? 1'b0 : 1'b1;
-  assign n_add_RD = (((add_RD)) + 4'h1);
+  assign n_add_RD = (add_RD) + 4'h1;
   always @(posedge clk_RD, posedge rst) begin
     if((rst == 1'b1)) begin
       add_RD <= {5{1'b0}};
@@ -132,8 +132,8 @@ reg isrst_r;
         add_RD_GCwc[0] <= n_add_RD[0] ^ n_add_RD[1];
         add_RD_GCwc[1] <= n_add_RD[1] ^ n_add_RD[2];
         add_RD_GCwc[2] <= n_add_RD[2] ^ n_add_RD[3];
-        add_RD_GCwc[3] <= n_add_RD[3] ^ (( ~n_add_RD[4]));
-        add_RD_GCwc[4] <= ( ~n_add_RD[4]);
+        add_RD_GCwc[3] <= n_add_RD[3] ^ ( ~n_add_RD[4]);
+        add_RD_GCwc[4] <=  ~n_add_RD[4];
       end
       else begin
         add_RD <= add_RD;

--- a/translated_examples/ifchain2.v
+++ b/translated_examples/ifchain2.v
@@ -11,7 +11,7 @@ output reg result
 
 
 reg [3:0] counter;
-parameter CLK_DIV_VAL = (11);
+parameter CLK_DIV_VAL = 11;
 
   always @(posedge clk, posedge rstn) begin
     if((rstn == 1'b0)) begin

--- a/translated_examples/mem.v
+++ b/translated_examples/mem.v
@@ -21,11 +21,11 @@ parameter [31:0] bus_width=14;
 reg [bus_width - 1:0] mem[255:0];
 reg [addr_width - 1:0] al = 8'h00;
 
-  assign dout = mem[(al)];
+  assign dout = mem[al];
   always @(posedge clk) begin
     al <= addr;
     if(en == 1'b1) begin
-      mem[(addr)] <= din;
+      mem[addr] <= din;
     end
   end
 

--- a/translated_examples/test.v
+++ b/translated_examples/test.v
@@ -121,7 +121,7 @@ reg [1:0] colour;
       3'b101 : code[9:2] <= 8'b11100010;
       3'b010 : code[9:2] <= {8{1'b1}};
       3'b011 : code[9:2] <= {8{1'b0}};
-      default : code[9:2] <= (((a)) + ((b)));
+      default : code[9:2] <= (a) + (b);
     endcase
   end
 
@@ -172,7 +172,7 @@ reg [1:0] colour;
     // Outputs
     .dout(memdin));
 
-  assign complex = {enf,((3'b110 * ((load)))),qtd[3:0],base,5'b11001};
+  assign complex = {enf,3'b110 * (load),qtd[3:0],base,5'b11001};
   assign enf = c < 7'b1000111 ? 1'b1 : 1'b0;
   assign eno = enf;
 


### PR DESCRIPTION
Unuseful extra parentheses when conversion function are used were removed. Additionally, analysis whith GHDL and iVerilog was added to be done always if installed.