### PR TITLE
Add 'install' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,19 +16,23 @@ VHDLS   := $(filter-out $(EXCLUDE),$(VHDLS))
 DIFFOPT := $(DIFFOPT) --exclude-from=examples/exclude
 endif
 
-all: diff
+BINARY   = src/vhd2vl
 
-translate:
-	@make -C src
+all: $(BINARY)
+
+build $(BINARY):
+	make -C src
+
+install: $(BINARY)
+	cp $< /usr/local/bin
+
+test: $(BINARY)
 	@make -C examples
-	@rm -fr $(TEMP)/verilog
-	@mkdir -p $(TEMP)/verilog
+	@rm -fr $(TEMP)/verilog && mkdir -p $(TEMP)/verilog
 	@echo "##### Translating Examples #####################################"
 	@cd examples; $(foreach VHDL,$(VHDLS), echo "Translating: $(VHDL)";\
-	../src/vhd2vl --quiet $(VHDL) ../$(TEMP)/verilog/$(basename $(VHDL)).v;)
+	../$(BINARY) --quiet $(VHDL) ../$(TEMP)/verilog/$(basename $(VHDL)).v;)
 	@make -C translated_examples
-
-diff: translate
 	@echo "##### Diff #####################################################"
 	diff -u $(DIFFOPT) translated_examples $(TEMP)/verilog
 	@echo "PASS"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ VHDLS   := $(filter-out $(EXCLUDE),$(VHDLS))
 DIFFOPT := $(DIFFOPT) --exclude-from=examples/exclude
 endif
 
+PREFIX  ?= /usr/local
+BINDIR  ?= $(PREFIX)/bin
 BINARY   = src/vhd2vl
 
 all: $(BINARY)
@@ -24,7 +26,7 @@ build $(BINARY):
 	make -C src
 
 install: $(BINARY)
-	cp $< /usr/local/bin
+	cp $< $(BINDIR)
 
 test: $(BINARY)
 	@make -C examples

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ It is also verified to work with recent tinycc from its git mob.
 This is portable C89/C99 code.  It can be expected to work with any
 fairly recent version of the required tools.
 
-To install, copy the resulting src/vhd2vl file to someplace in
-your *$PATH*, like *$HOME/bin* or */usr/local/bin*.
+To install, you can either type `make install` to copy the resulting src/vhd2vl
+file to */usr/local/bin*, or copy it manually to someplace in your *$PATH*, like
+*$HOME/bin*.
 
 ## 2.0 HOW TO USE vhd2vl:
 


### PR DESCRIPTION
Hi Larry,

TL; DR: I added the typical `make install`. Additionally, I removed the requirement to run tests when creating the binary, as it might be unnecessary for some users.

I encountered these inconveniences while installing `vhd2vl` in a Docker container (https://github.com/PyFPGA/containers), so I made these changes from a user’s perspective.
