### PR TITLE
Document the new --version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ There are a few options available on the command line:
 * `--debug` turn ON debugging within the yacc (bison) parser
 * `--src 1995|2001` to specify module declaration style
 * `--quiet` to avoid print vhd2vl header in translated_file.v
+* `--version` to print vhd2vl version and info from git, if available
 
 ## 3.0 TROUBLESHOOTING:
 


### PR DESCRIPTION
I noticed that `--version` was not documented, so I added it for completeness. I'm using this new option ;-) (https://github.com/PyFPGA/containers/blob/main/tests/langutils.sh)