### PR TITLE
Add ci for test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,17 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt update && sudo apt install -y build-essential flex bison iverilog
+      run: sudo apt-get update && sudo apt-get install -y build-essential flex bison iverilog
     - name: Build
-      run: make -j$(nproc)
+      run: make
     - name: Install and print version
       run: sudo make install && vhd2vl --version
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: vhd2vl
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt update && sudo apt install -y build-essential flex bison iverilog
+    - name: Build
+      run: make -j$(nproc)
+    - name: Install and print version
+      run: sudo make install && vhd2vl --version
+    - name: Test
+      run: make test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ http://doolittle.icarus.com/~larry/vhd2vl/
 
 ## 1.0 HOW TO BUILD AND INSTALL vhd2vl:
 
+Install the required dependencies for building and testing:
+```
+sudo apt install build-essential flex bison iverilog
+```
+
 To build, just type `make` in the src directory.
 
 This version of vhd2vl has been tested with


### PR DESCRIPTION
This PR adds CI for building and testing vhd2vl on each push. It also documents the dependencies required for these actions.