### PR TITLE
Patch: a clean branch from PR #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,3 @@ src/vhd2vl
 
 examples/*.o
 examples/*.cf
-
-# TODO
-TODO.md

--- a/src/vhd2vl.l
+++ b/src/vhd2vl.l
@@ -139,9 +139,7 @@ int scan_int(char *s);
 "std_ulogic_vector"               { return BITVECT; }
 "real"                            { return REAL; }
 "resize" |
-"to_unsigned" |
-"to_signed" |
-"conv_std_logic_vector"           { return CONVFUNC_2; }
+"to_unsigned"                     { return CONVFUNC_2; }
 "to_integer" |
 "conv_integer"                    { return CONVFUNC_1; }
 

--- a/src/vhd2vl.y
+++ b/src/vhd2vl.y
@@ -947,7 +947,7 @@ slist *emit_io_list(slist *sl)
 /* rule for "...ELSE IF edge THEN..." causes 1 shift/reduce conflict */
 /* rule for opt_begin causes 1 shift/reduce conflict */
 /* recursive design_units rule may cause additional conflicts */
-%expect 7
+%expect 3
 
 /* glr-parser is needed because processes can start with if statements, but
  * not have edges in them - more than one level of look-ahead is needed in that case
@@ -957,8 +957,10 @@ slist *emit_io_list(slist *sl)
 %%
 
 /* Input file can contain one or more entity-architecture pairs */
-trad  : design_units {
-          slprint($1);
+trad : design_units rem {
+        slist *sl;
+          sl=addsl($1,$2);
+          slprint(sl);
           $$=0;
         }
       ;
@@ -967,40 +969,37 @@ design_units : design_unit {
           $$=$1;
         }
       | design_units design_unit {
-          slist *sl;
-          sl=addsl($1,$2);
-          $$=sl;
-        }
-      ;
-
-design_unit : rem entity rem architecture rem {
         slist *sl;
-          sl=output_timescale($1);
-          sl=addsl(sl,$2);
-          sl=addsl(sl,$3);
-          sl=addsl(sl,$4);
-          sl=addtxt(sl,"\nendmodule\n");
-          sl=addsl(sl,$5);
+          sl=addsl($1,$2);
           $$=sl;
         }
 /* some people put entity declarations and architectures in separate files -
  * translate each piece - note that this will not make a legal Verilog file
  * - let them take care of that manually
  */
-      | rem entity rem  {
+      | rem entity {
         slist *sl;
           sl=output_timescale($1);
           sl=addsl(sl,$2);
-          sl=addtxt(sl,"\nendmodule\n");
-          sl=addsl(sl,$3);
+          sl=addtxt(sl,"\nendmodule  // incomplete: entity-only\n");
           $$=sl;
         }
-      | rem architecture rem {
+      | rem architecture {
         slist *sl;
           sl=output_timescale($1);
           sl=addsl(sl,$2);
-          sl=addtxt(sl,"\nendmodule\n");
+          sl=addtxt(sl,"\nendmodule  // incomplete: architecture-only\n");
+          $$=sl;
+        }
+      ;
+
+design_unit : rem entity rem architecture {
+        slist *sl;
+          sl=output_timescale($1);
+          sl=addsl(sl,$2);
           sl=addsl(sl,$3);
+          sl=addsl(sl,$4);
+          sl=addtxt(sl,"\nendmodule\n");
           $$=sl;
         }
       ;

--- a/translated_examples/Scientific.v
+++ b/translated_examples/Scientific.v
@@ -1,3 +1,4 @@
+// no timescale needed
 
 module Scientific(
 input wire clk
@@ -12,4 +13,4 @@ parameter exp5=50.0e-3;
 
 
 
-endmodule
+endmodule  // incomplete: entity-only

--- a/translated_examples/concat.v
+++ b/translated_examples/concat.v
@@ -1,3 +1,4 @@
+// no timescale needed
 
 module concat_demo(
 input wire reset
@@ -9,4 +10,4 @@ parameter [31:0] xyz=8'hff;
 
 
 
-endmodule
+endmodule  // incomplete: entity-only

--- a/translated_examples/multi_entity.v
+++ b/translated_examples/multi_entity.v
@@ -23,9 +23,9 @@ output reg [7:0] q
     end
   end
 
-// Second entity: Simple adder
 
 endmodule
+// Second entity: Simple adder
 
 module simple_adder(
 input wire [7:0] a,


### PR DESCRIPTION
This is a clean PR following the discussion in #27 . It applies the provided patch to resolve grammar conflicts and fix endmodule placement. As requested, the `empty string syntax error` fix is excluded for now.