### PR TITLE
Preserve signedness expr in `BITVECT` to support semantic converison

### DIFF
--- a/examples/conv_integer.vhd
+++ b/examples/conv_integer.vhd
@@ -1,0 +1,18 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+
+entity conv_integer_demo is
+  port(
+    s  : in  std_logic_vector(7 downto 0);
+    u  : out integer;
+    i  : out integer
+  );
+end conv_integer_demo;
+
+architecture rtl of conv_integer_demo is
+begin
+  -- conv_integer should be parsed as CONVFUNC_1 and preserved as expr
+  u <= conv_integer(unsigned(s)+1);
+  i <= conv_integer(signed(s));
+end rtl;

--- a/examples/conv_integer.vhd
+++ b/examples/conv_integer.vhd
@@ -2,17 +2,43 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 
+entity conv_integer_sink is
+  port(
+    val_u : in integer;
+    val_i : in integer
+  );
+end entity;
+
+architecture rtl of conv_integer_sink is
+begin
+  -- keep empty, only for verifying expression conversion in port map
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+
 entity conv_integer_demo is
   port(
-    s  : in  std_logic_vector(7 downto 0);
-    u  : out integer;
-    i  : out integer
+    s : in  std_logic_vector(7 downto 0);
+    u : out integer;
+    i : out integer
   );
-end conv_integer_demo;
+end entity;
 
 architecture rtl of conv_integer_demo is
+  constant s_test_neg : std_logic_vector(7 downto 0) := x"FF";
 begin
   -- conv_integer should be parsed as CONVFUNC_1 and preserved as expr
   u <= conv_integer(unsigned(s)+1);
   i <= conv_integer(signed(s));
-end rtl;
+
+  -- conv_integer in port map, using constant for static expression
+  sink_inst : entity work.conv_integer_sink
+    port map(
+      -- expected 255
+      val_u => conv_integer(unsigned(s_test_neg)),
+      -- expected -1
+      val_i => conv_integer(signed(s_test_neg))
+    );
+end architecture;

--- a/examples/fifo.vhd
+++ b/examples/fifo.vhd
@@ -67,12 +67,12 @@ process (clk_WR)
 begin
 	if (rising_edge(clk_WR)) then
 		if ((WR = '1') and (ifull = '0')) then
-			--ram_mem(to_integer(unsigned(add_WR(3 downto 0)))) <= D;
+			ram_mem(to_integer(unsigned(add_WR(3 downto 0)))) <= D;
 		end if;
 	end if;
 end process;
 
-	--Q <= ram_mem(to_integer(unsigned(add_RD(3 downto 0))));
+	Q <= ram_mem(to_integer(unsigned(add_RD(3 downto 0))));
 
 -----------------------------------------
 ----- Write address counter -------------

--- a/src/vhd2vl.l
+++ b/src/vhd2vl.l
@@ -137,7 +137,7 @@ static void replace_dash(char *s);
 "signed" |
 "unsigned" |
 "std_logic_vector" |
-"std_ulogic_vector"               { return BITVECT; }
+"std_ulogic_vector"               { yylval.txt=xstrdup(yytext); return BITVECT; }
 "real"                            { return REAL; }
 "resize" |
 "to_signed" |
@@ -145,7 +145,7 @@ static void replace_dash(char *s);
 "conv_std_logic_vector" |
 "conv_std_ulogic_vector"          { return CONVFUNC_2; }
 "to_integer" |
-"conv_integer"                    { return CONVFUNC_1; }
+"conv_integer"                    { yylval.txt=xstrdup(yytext); return CONVFUNC_1; }
 
 "shift_left"                      { return SHIFT_LEFT; }
 "shift_right"                     { return SHIFT_RIGHT; }

--- a/src/vhd2vl.y
+++ b/src/vhd2vl.y
@@ -2735,8 +2735,8 @@ expr : signal {
        }
        free($1);
       }
-     | CONVFUNC_1 '(' {convfunc1_sgn=1;} expr ')' {
-       convfunc1_sgn=0;
+     | CONVFUNC_1 '(' {convfunc1_sgn++;} expr ')' {
+       convfunc1_sgn--;
        $$ = addnest($4);
        free($1);
       }
@@ -3012,11 +3012,11 @@ simple_expr : signal {
      | simple_expr '/' simple_expr {
        $$=addexpr($1,'/'," / ",$3);
       }
-     | CONVFUNC_1 '(' {convfunc1_sgn=1;} simple_expr ')' {
+     | CONVFUNC_1 '(' {convfunc1_sgn++;} simple_expr ')' {
        /* one argument type conversion e.g. to_integer(x) */
        expdata *e;
        e=xmalloc(sizeof(expdata));
-       convfunc1_sgn=0;
+       convfunc1_sgn--;
        e->sl=addsl(NULL,$4->sl);
        e->op='e';
        $$=e;

--- a/translated_examples/conv_integer.v
+++ b/translated_examples/conv_integer.v
@@ -1,5 +1,18 @@
 // no timescale needed
 
+module conv_integer_sink(
+input wire [31:0] val_u,
+input wire [31:0] val_i
+);
+
+
+
+
+
+    // keep empty, only for verifying expression conversion in port map
+
+endmodule
+
 module conv_integer_demo(
 input wire [7:0] s,
 output wire [31:0] u,
@@ -9,9 +22,17 @@ output wire [31:0] i
 
 
 
+parameter s_test_neg = 8'hFF;
 
   // conv_integer should be parsed as CONVFUNC_1 and preserved as expr
   assign u = $unsigned(s) + 1;
   assign i = $signed(s);
+  // conv_integer in port map, using constant for static expression
+  conv_integer_sink sink_inst(
+    // expected 255
+    .val_u($unsigned(s_test_neg)),
+    // expected -1
+    .val_i($signed(s_test_neg)));
+
 
 endmodule

--- a/translated_examples/conv_integer.v
+++ b/translated_examples/conv_integer.v
@@ -1,0 +1,17 @@
+// no timescale needed
+
+module conv_integer_demo(
+input wire [7:0] s,
+output wire [31:0] u,
+output wire [31:0] i
+);
+
+
+
+
+
+  // conv_integer should be parsed as CONVFUNC_1 and preserved as expr
+  assign u = $unsigned(s) + 1;
+  assign i = $signed(s);
+
+endmodule

--- a/translated_examples/dsp.v
+++ b/translated_examples/dsp.v
@@ -28,7 +28,7 @@ wire foo;
 reg [63:0] sr;
 wire [31:0] iparam;
 
-  assign iparam = param;
+  assign iparam = $unsigned(param);
   always @(posedge clk) begin
       // dout <= std_logic_vector(to_unsigned(1,bus_width));
     if(we == 1'b1) begin

--- a/translated_examples/fifo.v
+++ b/translated_examples/fifo.v
@@ -41,7 +41,7 @@ parameter [31:0] data_width=8;
 
 
 
-wire [data_width - 1:0] ram_mem[15:0];
+reg [data_width - 1:0] ram_mem[15:0];
 wire iempty;
 wire ifull;
 wire add_WR_CE;
@@ -65,11 +65,11 @@ reg isrst_r;
   //------------------------------------------
   always @(posedge clk_WR) begin
     if(((WR == 1'b1) && (ifull == 1'b0))) begin
-      //ram_mem(to_integer(unsigned(add_WR(3 downto 0)))) <= D;
+      ram_mem[$unsigned(add_WR[3:0])] <= D;
     end
   end
 
-  //Q <= ram_mem(to_integer(unsigned(add_RD(3 downto 0))));
+  assign Q = ram_mem[$unsigned(add_RD[3:0])];
   //---------------------------------------
   //--- Write address counter -------------
   //---------------------------------------


### PR DESCRIPTION
See #35 . 

Hi, @ldoolitt . I've managed to complete test cases and refine `convfunc1_sgn` handling in `BITVECT`. Now `vhd2vl` can correctly parse `conv_integer` and `to_integer` even with an expr like `conv_integer(unsigned(s)+1)`.